### PR TITLE
Generate SwaggerUI

### DIFF
--- a/src/main/java/org/codehaus/mojo/servicedocgen/Analyzer.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/Analyzer.java
@@ -403,6 +403,7 @@ public class Analyzer
     {
         Method annotatedParentMethod = byteMethod;
         Path methodPath = null;
+        boolean exit = false;
         do
         {
             methodPath = annotatedParentMethod.getAnnotation( Path.class );
@@ -411,14 +412,32 @@ public class Analyzer
                 annotatedParentMethod = this.reflectionUtil.getParentMethod( annotatedParentMethod );
                 if ( annotatedParentMethod == null )
                 {
-                    return null;
+                    exit = true;
                 }
             }
         }
-        while ( methodPath == null );
+        while ( !exit && methodPath == null );
 
         OperationDescriptor operationDescriptor = new OperationDescriptor();
-        operationDescriptor.setPath( methodPath.value() );
+        if( methodPath == null )
+        {
+            methodPath = byteMethod.getDeclaringClass().getAnnotation( Path.class );
+            if( methodPath == null )
+            {
+                return null;
+            }
+            annotatedParentMethod = byteMethod;
+            operationDescriptor.setPath( "/" );
+        } else
+        {
+            if( !methodPath.value().startsWith( "/" ) )
+            {
+                operationDescriptor.setPath( "/" + methodPath.value() );
+            } else
+            {
+                operationDescriptor.setPath( methodPath.value() );
+            }
+        }
 
         if ( this.annotationUtil.getMethodAnnotation( byteMethod, Deprecated.class ) != null )
         {

--- a/src/main/java/org/codehaus/mojo/servicedocgen/ServiceDocGenReport.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/ServiceDocGenReport.java
@@ -302,7 +302,7 @@ public class ServiceDocGenReport
                     throw new MojoExecutionException( "Could not create directory " + reportDirectory );
                 }
             }
-            generator.generate( services, reportDirectory, outputName );
+            generator.generate( services, reportDirectory, outputName, openApiUrl );
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/servicedocgen/ServiceDocGenReport.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/ServiceDocGenReport.java
@@ -166,7 +166,7 @@ public class ServiceDocGenReport
         return true;
     }
     
-    protected String getOutputDirectory()
+    protected String getOutputDirectoryPath()
     {
         return this.outputDirectory.getAbsolutePath();
     }
@@ -176,9 +176,11 @@ public class ServiceDocGenReport
         if( CollectionUtils.isEmpty( this.templates ) )
         {
             this.templates = new ArrayList<ServiceDocGenTemplate>();
-            this.templates.add( new ServiceDocGenTemplate( "Service-Documentation.html.vm", "index.html" ) );
-            this.templates.add( new ServiceDocGenTemplate( "OpenApi.yaml.vm", "openapi.yaml" ) );
-            this.templates.add( new ServiceDocGenTemplate( "SwaggerUI.html.vm", "swagger.html" ) );
+            ServiceDocGenTemplate template = new ServiceDocGenTemplate( "Service-Documentation.html.vm" );
+            template.setOutputName( "index.html" );
+            this.templates.add( template );
+            this.templates.add( new ServiceDocGenTemplate( "OpenApi.yaml.vm" ) );
+            this.templates.add( new ServiceDocGenTemplate( "SwaggerUI.html.vm" ) );
         }
         return this.templates;
     }
@@ -273,15 +275,9 @@ public class ServiceDocGenReport
         String openApiUrl = "";
         for( ServiceDocGenTemplate template : this.getTemplates() )
         {
-            if( template.getTemplateName().equals( "OpenApi.yaml.vm" ) )
+            if( template.getTemplateName().equals( "OpenApi.yaml.vm" ) || template.getTemplateName().equals( "OpenApi.json.vm" ) )
             {
-                openApiUrl = "openapi.yaml";
-                break;
-            }
-                
-            if( template.getTemplateName().equals( "OpenApi.json.vm" ) )
-            {
-                openApiUrl = "openapi.json";
+                openApiUrl = template.getOutputNameWithFallback();
                 break;
             }
         }
@@ -293,7 +289,7 @@ public class ServiceDocGenReport
             getLog().info( "Generating output file " + outputName + " for " + templateName + "..." );
             ServicesGenerator generator =
                 new VelocityServicesGenerator( Util.appendPath( this.templatePath, templateName ) );
-            File reportDirectory = new File( this.getOutputDirectory(), this.reportFolder );
+            File reportDirectory = new File( this.getOutputDirectoryPath(), this.reportFolder );
             if ( !reportDirectory.isDirectory() )
             {
                 boolean ok = reportDirectory.mkdirs();

--- a/src/main/java/org/codehaus/mojo/servicedocgen/ServiceDocGenTemplate.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/ServiceDocGenTemplate.java
@@ -11,11 +11,10 @@ public class ServiceDocGenTemplate
     public ServiceDocGenTemplate()
     {
     }
-
-    public ServiceDocGenTemplate( String templateName, String outputName )
+    
+    public ServiceDocGenTemplate( String templateName )
     {
         this.templateName = templateName;
-        this.outputName = outputName;
     }
 
     private String templateName;

--- a/src/main/java/org/codehaus/mojo/servicedocgen/generation/ServicesGenerator.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/generation/ServicesGenerator.java
@@ -26,7 +26,7 @@ import org.codehaus.mojo.servicedocgen.descriptor.ServicesDescriptor;
 /**
  * Interface for a generator that creates documentation for a given {@link ServicesDescriptor}.
  *
- * @see #generate(ServicesDescriptor, File, String)
+ * @see #generate(ServicesDescriptor, File, String, String)
  * @author hohwille
  */
 public interface ServicesGenerator
@@ -38,9 +38,10 @@ public interface ServicesGenerator
      * @param descriptor the {@link ServicesDescriptor} with the collected meta-data.
      * @param outputDirectory the {@link File#isDirectory() directory} where to write the output to.
      * @param filename the name of the file to write the output to.
+     * @param openApiUrl the url to the OpenApi file
      * @throws IOException if something goes wrong.
      */
-    void generate( ServicesDescriptor descriptor, File outputDirectory, String filenamet, String openApiUrl )
+    void generate( ServicesDescriptor descriptor, File outputDirectory, String filename, String openApiUrl )
         throws IOException;
 
 }

--- a/src/main/java/org/codehaus/mojo/servicedocgen/generation/ServicesGenerator.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/generation/ServicesGenerator.java
@@ -40,7 +40,7 @@ public interface ServicesGenerator
      * @param filename the name of the file to write the output to.
      * @throws IOException if something goes wrong.
      */
-    void generate( ServicesDescriptor descriptor, File outputDirectory, String filename )
+    void generate( ServicesDescriptor descriptor, File outputDirectory, String filenamet, String openApiUrl )
         throws IOException;
 
 }

--- a/src/main/java/org/codehaus/mojo/servicedocgen/generation/velocity/VelocityServicesGenerator.java
+++ b/src/main/java/org/codehaus/mojo/servicedocgen/generation/velocity/VelocityServicesGenerator.java
@@ -77,11 +77,12 @@ public class VelocityServicesGenerator
      * {@inheritDoc}
      */
     @Override
-    public void generate( ServicesDescriptor descriptor, File outputDirectory, String filename )
+    public void generate( ServicesDescriptor descriptor, File outputDirectory, String filename, String openApiUrl )
         throws IOException
     {
         this.context.put( "services", descriptor );
         this.context.put( "EscapeHelper", EscapeHelper.class );
+        this.context.put("openApiUrl", openApiUrl);
         File outputFile = new File( outputDirectory, filename );
         OutputStream out = new FileOutputStream( outputFile );
         try

--- a/src/main/resources/org/codehaus/mojo/servicedocgen/generation/velocity/OpenApi.json.vm
+++ b/src/main/resources/org/codehaus/mojo/servicedocgen/generation/velocity/OpenApi.json.vm
@@ -14,6 +14,11 @@
       "url": "$services.info.license.url"
     }
   },
+  "servers": [
+    {
+      "url": "$services.host:$services.port/$services.basePath"
+    }
+  ],
   "paths": {
 #foreach ($service in $services.services)
 #foreach ($operation in $service.operations)

--- a/src/main/resources/org/codehaus/mojo/servicedocgen/generation/velocity/OpenApi.yaml.vm
+++ b/src/main/resources/org/codehaus/mojo/servicedocgen/generation/velocity/OpenApi.yaml.vm
@@ -11,6 +11,9 @@ info:
     name: $services.info.license.name
     url: $services.info.license.url
     
+servers:
+  - url: $services.host:$services.port/$services.basePath
+    
 paths:
 #foreach ($service in $services.services)
 #foreach ($operation in $service.operations)

--- a/src/main/resources/org/codehaus/mojo/servicedocgen/generation/velocity/SwaggerUI.html.vm
+++ b/src/main/resources/org/codehaus/mojo/servicedocgen/generation/velocity/SwaggerUI.html.vm
@@ -1,0 +1,52 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.47.1/swagger-ui.css" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.47.1/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.47.1/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script>
+      window.onload = function() {
+        const ui = SwaggerUIBundle({
+        url: './$openApiUrl',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis,SwaggerUIStandalonePreset],
+        plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+        layout: 'StandaloneLayout',
+      })
+
+            
+      window.ui = ui;
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Created a new template into which the OpenApi specification can be passed to create a completely working Swagger UI. Added a new parameter to specify the output directory of the files, so that the files can be served directly with an application (e.g. Quarkus, Spring) without the need for a separate web server.